### PR TITLE
Create .dockerignore, symlinked from .gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.*
 build/
 release/develop
 release/*/*.iso


### PR DESCRIPTION
This saves transferring build/ and release/ to the Docker context. These
directories can be heavy. Remove the .* pattern from .gitignore to allow
for the creation of .dockerignore.